### PR TITLE
Add sensitive property to certificate sourced from content passed to the resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the trusted_certificat
 
 ## Unreleased
 
+- Add sensitive property to certificate sourced from content passed to the resource - [@bmhughes](https://github.com/bmhughes)
+
 ## 3.4.0 - *2021-03-18*
 
 - Sous Chefs Adoption

--- a/resources/trusted_certificate.rb
+++ b/resources/trusted_certificate.rb
@@ -22,6 +22,7 @@ provides :trusted_certificate
 
 property :certificate_name, String, name_property: true
 property :content, String, required: [:create]
+property :sensitive, [true, false], default: true
 
 action :create do
   execute 'update trusted certificates' do
@@ -32,7 +33,7 @@ action :create do
   if new_resource.content.start_with?('cookbook_file://')
     src = new_resource.content.split('://')[1].split('::')
     cookbook_file "#{certificate_path}/#{new_resource.certificate_name}.crt" do
-      sensitive new_resource.sensitive if new_resource.sensitive
+      sensitive new_resource.sensitive
       source src[-1]
       cookbook src.length == 2 ? src[0] : cookbook_name
       owner 'root'
@@ -41,7 +42,7 @@ action :create do
     end
   elsif new_resource.content =~ %r{^[a-zA-Z]*://.*}
     remote_file "#{certificate_path}/#{new_resource.certificate_name}.crt" do
-      sensitive new_resource.sensitive if new_resource.sensitive
+      sensitive new_resource.sensitive
       source new_resource.content
       owner 'root'
       group 'staff' if platform_family?('debian')
@@ -49,6 +50,7 @@ action :create do
     end
   else
     file "#{certificate_path}/#{new_resource.certificate_name}.crt" do
+      sensitive new_resource.sensitive
       content new_resource.content
       owner 'root'
       group 'staff' if platform_family?('debian')


### PR DESCRIPTION
# Description

Add sensitive property to certificate sourced from content passed to the resource

## Issues Resolved

- n/a

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
